### PR TITLE
fix: existingEntityNames are not filled in case microservice architec…

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -267,36 +267,34 @@ module.exports = class extends BaseGenerator {
             }
         };
 
-        const prompts = !this.uaaAuthentication
-            ? askMicroservicePath
-            : [
-                {
-                    type: 'list',
-                    name: 'clientType',
-                    message: 'Which feign client do you want to generate?',
-                    choices: [
-                        {
-                            name: 'other microservice entities',
-                            value: 'microservice'
-                        },
-                        {
-                            name: 'uaa service user and authority entities',
-                            value: 'uaa'
-                        }
-                    ],
-                    default: 'microservice'
-                },
-                askMicroservicePath,
-                {
-                    when: response => response.clientType === 'microservice',
-                    type: 'checkbox',
-                    name: 'entitiesNames',
-                    message: 'Please choose the entities to be audited',
-                    choices: response =>
-                        getEntityList(response.microservicePath),
-                    default: 'none'
-                }
-            ];
+        const prompts = [
+            {
+                type: 'list',
+                name: 'clientType',
+                message: 'Which feign client do you want to generate?',
+                choices: [
+                    {
+                        name: 'other microservice entities',
+                        value: 'microservice'
+                    },
+                    {
+                        name: 'uaa service user and authority entities',
+                        value: 'uaa'
+                    }
+                ],
+                default: 'microservice'
+            },
+            askMicroservicePath,
+            {
+                when: response => response.clientType === 'microservice',
+                type: 'checkbox',
+                name: 'entitiesNames',
+                message: 'Please choose the entities to be audited',
+                choices: response =>
+                    getEntityList(response.microservicePath),
+                default: 'none'
+            }
+        ];
 
         const done = this.async();
         this.prompt(prompts).then((props) => {


### PR DESCRIPTION
…ture is pre-choosen

if uaaAuthentication is false, the entitiesNames are not filled. That causes:

TypeError: Cannot read property 'forEach' of undefined
    at module.exports.writing (/usr/local/lib/node_modules/generator-jhipster-feign-client/generators/app/index.js:334:32)

Promt always the choice selection for uaa & microservice